### PR TITLE
Fix: nginx DNS resolution for production deployment

### DIFF
--- a/dist/docker/nginx.conf
+++ b/dist/docker/nginx.conf
@@ -44,6 +44,9 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=ui:10m rate=50r/s;
 
+    # Enable dynamic DNS resolution for Docker containers
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
     server {
         listen 80;
         server_name _;
@@ -67,7 +70,8 @@ http {
         # API proxy with rate limiting
         location /api/ {
             limit_req zone=api burst=20 nodelay;
-            proxy_pass http://synaptik-backend:9001/api/;
+            set $backend "api:9001";
+            proxy_pass http://$backend/api/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -80,7 +84,8 @@ http {
         # MCP Server-Sent Events endpoint
         location /mcp {
             limit_req zone=api burst=5 nodelay;
-            proxy_pass http://synaptik-backend:9001/mcp;
+            set $backend "api:9001";
+            proxy_pass http://$backend/mcp;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -98,7 +103,8 @@ http {
         # Quarkus health endpoints
         location /q/ {
             limit_req zone=api burst=10 nodelay;
-            proxy_pass http://synaptik-backend:9001/q/;
+            set $backend "api:9001";
+            proxy_pass http://$backend/q/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Problem
Production deployment was failing with nginx error:
```
host not found in upstream 'synaptik-backend'
```

## Root Cause
1. **Service name mismatch**: nginx was trying to resolve 'synaptik-backend' but the actual service name is 'api'
2. **DNS resolution timing**: nginx was attempting to resolve upstream at startup before backend container was ready
3. **Static upstream configuration**: nginx couldn't handle dynamic service discovery

## Solution
### 1. Correct Service Name
- Changed upstream from `synaptik-backend:9001` to `api:9001`
- This matches the actual Docker service name defined in docker-compose

### 2. Dynamic DNS Resolution
- Added variable-based proxy_pass: `set $upstream api:9001;`
- This forces nginx to resolve DNS at request time, not startup time
- Prevents startup failures when backend isn't immediately available

### 3. Docker Resolver Configuration
- Added `resolver 127.0.0.11 valid=30s;`
- Uses Docker's internal DNS resolver
- 30-second cache validity for performance

## Changes
- **File**: `dist/docker/nginx.conf`
- **Impact**: Production deployment stability
- **Testing**: Verified service name matches docker-compose configuration

## Verification
✅ Service name 'api' matches docker-compose.yml  
✅ Dynamic DNS resolution handles startup timing  
✅ Docker resolver configured for container networking  

This fix ensu
## Solution
### 1. Correct Service Name
- Changed upstream from `synaptis of container startup or- Chan