### PR TITLE
Fix: GitHub Actions permissions for version bumping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: read
+  contents: write  # Required for version bumping and pushing tags
   security-events: write
   actions: read
 


### PR DESCRIPTION
Fixes the permission denied error in the CI/CD pipeline that prevents version bumping.

## Problem
The GitHub Actions workflow was failing with:
```
remote: Permission to Dukeroyahl/Synaptik.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/Dukeroyahl/Synaptik/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

## Root Cause
The workflow permissions were set to `contents: read` but the auto-versioning job needs `contents: write` to:
- Push version bump commits
- Create and push git tags
- Update package.json and config files

## Solution
Changed permissions from `contents: read` to `contents: write` in the workflow file.

## Impact
- Enables automatic version bumping on main branch merges
- Allows proper tagging and release creation
- Fixes failing CI/CD pipeline for version management