### PR TITLE
Fix: Automate install script for unattended execution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,12 +97,7 @@ if [ "$IS_UPDATE" = true ]; then
     
     if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "unknown" ]; then
         log_warning "You already have the latest version ($LATEST_VERSION)"
-        echo "Do you want to continue anyway? This will re-download all files. (y/N)"
-        read -r response
-        if [[ ! "$response" =~ ^[Yy]$ ]]; then
-            log_info "Installation cancelled"
-            exit 0
-        fi
+        log_info "Proceeding with re-download to ensure all files are up-to-date..."
     fi
 fi
 


### PR DESCRIPTION
Removes user prompt to make installation script fully automated.

## Problem
The install script prompts users when they already have the latest version:
```
⚠️ You already have the latest version (0.0.1)
Do you want to continue anyway? This will re-download all files. (y/N)
```

This blocks automated CI/CD workflows and scripted installations.

## Solution
- Automatically proceed with re-download when latest version is detected
- Remove the interactive (y/N) prompt completely
- Always ensure files are up-to-date regardless of version numbers

## Benefits
✅ Fully automated installation for CI/CD pipelines
✅ No user interaction required for scripted deployments
✅ Ensures all files are always refreshed and up-to-date
✅ Maintains same functionality but removes blocking prompts

## Impact
This change allows the install script to be used in:
- Automated deployment scripts
- CI/CD workflows
- Docker builds
- Any scenario requiring unattended installation