### PR TITLE
fix: add conventional commits link to README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Docker](https://img.shields.io/docker/pulls/roudranil/synaptik?logo=docker&color=2496ED)](https://hub.docker.com/r/roudranil/synaptik)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[🚀 Quick Start](#-quick-start) • [📚 Wiki Documentation](https://github.com/Dukeroyahl/Synaptik/wiki) • [🤝 Contributing](CONTRIBUTING.md)
+[🚀 Quick Start](#-quick-start) • [📚 Wiki Documentation](https://github.com/Dukeroyahl/Synaptik/wiki) • [🤝 Contributing](CONTRIBUTING.md) • [📝 Conventional Commits](https://github.com/Dukeroyahl/Synaptik/wiki/Conventional-Commits)
 
 </div>
 


### PR DESCRIPTION
## Summary

Improve documentation accessibility by adding a direct link to the conventional commits guide in the main README navigation.

### Changes

- Added conventional commits link to README navigation bar
- Links to wiki page for easy access to commit format guidelines

### Testing the Conventional Commits Workflow

This PR uses conventional commits format:
- Commit starts with `fix:` which should trigger a **patch** version bump
- When merged, should automatically create release branch and publish Docker images

### Benefits

- Better discoverability of conventional commits guidelines
- Easier onboarding for new contributors
- Consistent with other navigation links