### PR TITLE
fix: restore Docker infrastructure for CD pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,8 +222,13 @@ memory-*.json
 # PROJECT SPECIFIC
 # ===========================
 # Build artifacts
-dist/
-docker/
+/client/dist/
+/server/build/
+/mcp-server/dist/
+
+# Allow Docker infrastructure
+!dist/docker/
+!dist/docker-compose.yml
 
 # Test files
 test.txt

--- a/dist/docker-compose.yml
+++ b/dist/docker-compose.yml
@@ -1,0 +1,74 @@
+# Production Docker Compose for Synaptik
+# Uses container images for production deployment
+
+name: synaptik
+
+services:
+  # MongoDB Database
+  mongodb:
+    image: mongo:7.0
+    container_name: synaptik-mongodb
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_DATABASE: synaptik
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:-admin}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-changeme}
+    volumes:
+      - ${HOME}/.synaptik/data:/data/db
+      - ${SYNAPTIK_LOGS_DIR:-${HOME}/.synaptik/logs}/mongodb:/var/log/mongodb
+    expose:
+      - "27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    networks:
+      - synaptik-network
+
+  # Backend API Service  
+  api:
+    image: ${API_IMAGE:-ghcr.io/dukeroyahl/synaptik:backend-latest}
+    container_name: synaptik-api
+    ports:
+      - "${API_PORT:-9001}:9001"
+    environment:
+      - QUARKUS_PROFILE=prod
+      - MONGODB_URI=mongodb://${MONGO_ROOT_USERNAME:-admin}:${MONGO_ROOT_PASSWORD:-changeme}@mongodb:27017/synaptik?authSource=admin
+    volumes:
+      - ${SYNAPTIK_LOGS_DIR:-${HOME}/.synaptik/logs}/backend:/opt/synaptik/logs
+    restart: unless-stopped
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9001/q/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - synaptik-network
+
+  # Frontend UI Service
+  ui:
+    image: ${UI_IMAGE:-ghcr.io/dukeroyahl/synaptik:frontend-latest}
+    container_name: synaptik-ui
+    ports:
+      - "${HTTP_PORT:-4000}:80"
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - synaptik-network
+
+
+# User data is stored in ~/.synaptik/ on the host system
+# No Docker volumes needed - data persists across container updates
+
+networks:
+  synaptik-network:
+    name: synaptik-network
+    driver: bridge

--- a/dist/docker/.env.example
+++ b/dist/docker/.env.example
@@ -1,0 +1,69 @@
+# Synaptik Docker Compose Environment Configuration
+# Copy this file to .env and customize as needed
+
+# ==============================================
+# DATA PERSISTENCE CONFIGURATION
+# ==============================================
+
+# MongoDB data directory (absolute or relative path)
+# Default: Uses $HOME/.synaptik/data (user's home directory)
+SYNAPTIK_DATA_DIR=${HOME}/.synaptik/data
+
+# Application logs directory (absolute or relative path)  
+# Default: Uses $HOME/.synaptik/logs (user's home directory)
+SYNAPTIK_LOGS_DIR=${HOME}/.synaptik/logs
+
+# ==============================================
+# APPLICATION CONFIGURATION
+# ==============================================
+
+# Quarkus HTTP port (internal container port, don't change unless needed)
+QUARKUS_HTTP_PORT=9001
+
+# Frontend logging configuration
+VITE_LOG_LEVEL=debug
+VITE_LOG_TO_FILE=true
+
+# MCP Server logging
+MCP_LOG_LEVEL=debug
+
+# MongoDB connection (internal container connection, don't change)
+QUARKUS_MONGODB_CONNECTION_STRING=mongodb://mongodb:27017/synaptik
+
+# ==============================================
+# PERFORMANCE TUNING
+# ==============================================
+
+# Java memory settings (adjust based on your system)
+JAVA_OPTS=-Xmx512m -Xms256m
+
+# ==============================================
+# SECURITY CONFIGURATION
+# ==============================================
+
+# Change this in production!
+SYNAPTIK_SECRET_KEY=change-me-in-production
+
+# ==============================================
+# EXAMPLES OF CUSTOM DATA LOCATIONS
+# ==============================================
+
+# Store data in your home directory (default)
+# SYNAPTIK_DATA_DIR=${HOME}/.synaptik/data
+# SYNAPTIK_LOGS_DIR=${HOME}/.synaptik/logs
+
+# Store data in current project directory
+# SYNAPTIK_DATA_DIR=./synaptik-data
+# SYNAPTIK_LOGS_DIR=./synaptik-logs
+
+# Store data in specific location
+# SYNAPTIK_DATA_DIR=/var/lib/synaptik/data
+# SYNAPTIK_LOGS_DIR=/var/log/synaptik
+
+# Store data on external drive (Linux/Mac)
+# SYNAPTIK_DATA_DIR=/mnt/external/synaptik-data
+# SYNAPTIK_LOGS_DIR=/mnt/external/synaptik-logs
+
+# Store data on external drive (Windows via WSL)
+# SYNAPTIK_DATA_DIR=/mnt/d/synaptik-data
+# SYNAPTIK_LOGS_DIR=/mnt/d/synaptik-logs

--- a/dist/docker/Dockerfile.backend
+++ b/dist/docker/Dockerfile.backend
@@ -1,0 +1,37 @@
+# Multi-stage build for Synaptik Backend
+FROM gradle:8.14-jdk21-alpine AS backend-builder
+
+WORKDIR /app/server
+COPY server/gradle ./gradle
+COPY server/build.gradle server/settings.gradle server/gradle.properties ./
+COPY server/gradlew ./
+RUN chmod +x gradlew
+
+# Copy source and build
+COPY server/src ./src
+RUN ./gradlew clean build -x test
+
+# Runtime image
+FROM eclipse-temurin:21-jre-alpine
+
+# Install necessary packages
+RUN apk add --no-cache curl bash
+
+# Create application user
+RUN addgroup -g 1001 synaptik && adduser -D -u 1001 -G synaptik synaptik
+
+# Copy application
+COPY --from=backend-builder /app/server/build/quarkus-app /opt/synaptik/
+RUN chown -R synaptik:synaptik /opt/synaptik
+
+# Switch to non-root user
+USER synaptik
+WORKDIR /opt/synaptik
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:9001/q/health || exit 1
+
+EXPOSE 9001
+
+CMD ["java", "-jar", "quarkus-run.jar"]

--- a/dist/docker/Dockerfile.frontend
+++ b/dist/docker/Dockerfile.frontend
@@ -1,0 +1,36 @@
+# Multi-stage build for Synaptik Frontend
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app/client
+COPY client/package*.json ./
+
+# Install ALL dependencies (including dev dependencies needed for build)
+RUN npm ci
+
+# Copy source and build
+COPY client/ ./
+RUN npm run build
+
+# Runtime image with nginx
+FROM nginx:alpine
+
+# Copy built frontend
+COPY --from=frontend-builder /app/client/dist /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY dist/docker/nginx.conf /etc/nginx/nginx.conf
+
+# Create nginx user and set permissions
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    touch /var/run/nginx.pid && \
+    chown nginx:nginx /var/run/nginx.pid
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:80/ || exit 1
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/dist/docker/nginx.conf
+++ b/dist/docker/nginx.conf
@@ -1,0 +1,137 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    
+    access_log /var/log/nginx/access.log main;
+    
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/json
+        application/javascript
+        application/xml+rss
+        application/atom+xml
+        image/svg+xml;
+
+    # Rate limiting
+    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=ui:10m rate=50r/s;
+
+    # Enable dynamic DNS resolution for Docker containers
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
+    server {
+        listen 80;
+        server_name _;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        # API proxy with rate limiting
+        location /api/ {
+            limit_req zone=api burst=20 nodelay;
+            set $backend "api:9001";
+            proxy_pass http://$backend/api/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 30s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 30s;
+        }
+
+        # MCP Server-Sent Events endpoint
+        location /mcp {
+            limit_req zone=api burst=5 nodelay;
+            set $backend "api:9001";
+            proxy_pass http://$backend/mcp;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding off;
+            proxy_connect_timeout 30s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 300s;
+        }
+
+        # Quarkus health endpoints
+        location /q/ {
+            limit_req zone=api burst=10 nodelay;
+            set $backend "api:9001";
+            proxy_pass http://$backend/q/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Serve static files with caching
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            limit_req zone=ui burst=100 nodelay;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        # Serve React app (SPA routing)
+        location / {
+            limit_req zone=ui burst=50 nodelay;
+            try_files $uri $uri/ /index.html;
+            expires 24h;
+            add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+        }
+
+        # Error pages
+        error_page 404 /index.html;
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            root /usr/share/nginx/html;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Restore critical Docker files accidentally deleted during cleanup
- Fix CD pipeline failures caused by missing Docker infrastructure
- Update configurations for GitHub Container Registry

## Problem
The CD pipeline was failing with `ERROR: failed to build: resolve : lstat dist: no such file or directory` because Docker infrastructure files were accidentally deleted in commit 79b76e6 during cleanup.

## Solution
Restored essential Docker files:
- **Dockerfiles**: `dist/docker/Dockerfile.backend` and `dist/docker/Dockerfile.frontend` for multi-stage builds
- **Nginx Config**: `dist/docker/nginx.conf` with production-ready configuration 
- **Docker Compose**: `dist/docker-compose.yml` for production deployment
- **Environment Template**: `dist/docker/.env.example` for configuration

## Changes
- ✅ Restored all Docker infrastructure files from commit 79b76e6^
- ✅ Updated docker-compose.yml to use GitHub Container Registry (ghcr.io/dukeroyahl/synaptik)
- ✅ Fixed nginx configuration typo (`proxy_Set_header` → `proxy_set_header`)
- ✅ Updated .gitignore to properly allow Docker infrastructure while excluding build artifacts

## Test plan
- [x] CD pipeline should now successfully build Docker images
- [x] Manual workflow dispatch should complete without errors
- [x] Docker compose deployment should work with updated GHCR images

🤖 Generated with [Claude Code](https://claude.ai/code)