### PR TITLE
fix: ensure fully lowercase image names for GHCR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,6 +95,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set lowercase image name
+        id: image-name
+        run: |
+          echo "image_name=$(echo '${{ github.repository_owner }}/synaptik' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -103,8 +108,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.component }}-${{ needs.validate-release.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.component }}-latest
+            ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:${{ matrix.component }}-${{ needs.validate-release.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:${{ matrix.component }}-latest
           labels: |
             org.opencontainers.image.title=Synaptik ${{ matrix.component }}
             org.opencontainers.image.description=Synaptik ${{ matrix.component }} - TaskWarrior DNA task management


### PR DESCRIPTION
## Summary
- Add step to convert repository owner name to fully lowercase for GHCR compatibility
- Fix Docker build failures caused by mixed-case repository names

## Problem
CD pipeline still failing with the same error even after previous fix:
```
ERROR: invalid tag "ghcr.io/Dukeroyahl/synaptik:frontend-0.0.7": repository name must be lowercase
```

The issue was that `${{ github.repository_owner }}` returns `Dukeroyahl` with capital D, which violates GHCR's lowercase requirement.

## Solution
- Add dedicated step to create lowercase image name using `tr '[:upper:]' '[:lower:]'`
- Update Docker tags to use step output instead of environment variable
- Ensures all tags are consistently lowercase: `ghcr.io/dukeroyahl/synaptik:*`

## Test plan
- [x] CD workflow should now successfully build and push Docker images to GHCR
- [x] All image tags will be properly lowercase formatted

🤖 Generated with [Claude Code](https://claude.ai/code)