### PR TITLE
fix: remove non-existent Linux ARM64 binary references

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -270,17 +270,14 @@ jobs:
           **Available Platforms:**
           - 🍎 **macOS Apple Silicon** *(Primary platform - fully tested)*
           - 🐧 **Linux x86_64** 
-          - 🐧 **Linux ARM64**
           
           **Downloads for v$VERSION:**
           - [synaptik-mcp-darwin-arm64](https://github.com/dukeroyahl/synaptik/releases/download/v$VERSION/synaptik-mcp-darwin-arm64)
           - [synaptik-mcp-linux-amd64](https://github.com/dukeroyahl/synaptik/releases/download/v$VERSION/synaptik-mcp-linux-amd64)
-          - [synaptik-mcp-linux-arm64](https://github.com/dukeroyahl/synaptik/releases/download/v$VERSION/synaptik-mcp-linux-arm64)
           
           **Or get latest stable:**
           - [synaptik-mcp-darwin-arm64](https://github.com/dukeroyahl/synaptik/releases/latest/download/synaptik-mcp-darwin-arm64)
           - [synaptik-mcp-linux-amd64](https://github.com/dukeroyahl/synaptik/releases/latest/download/synaptik-mcp-linux-amd64)
-          - [synaptik-mcp-linux-arm64](https://github.com/dukeroyahl/synaptik/releases/latest/download/synaptik-mcp-linux-arm64)
           
           **Benefits:** Faster startup, lower memory usage, no Java runtime required
           

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ docker pull roudranil/synaptik/backend:latest
 
 ### 🔥 Native MCP Binaries (GitHub Releases)
 [![macOS ARM64](https://img.shields.io/badge/macOS%20ARM64-Available-success?logo=apple&logoColor=white)](https://github.com/dukeroyahl/synaptik/releases/latest/download/synaptik-mcp-darwin-arm64)
-[![Linux x86_64](https://img.shields.io/badge/Linux%20x86__64-Coming%20Soon-orange?logo=linux&logoColor=white)](https://github.com/dukeroyahl/synaptik/releases/latest)
-[![Linux ARM64](https://img.shields.io/badge/Linux%20ARM64-Available-success?logo=linux&logoColor=white)](https://github.com/dukeroyahl/synaptik/releases/latest/download/synaptik-mcp-linux-arm64)
+[![Linux x86_64](https://img.shields.io/badge/Linux%20x86__64-Available-success?logo=linux&logoColor=white)](https://github.com/dukeroyahl/synaptik/releases/latest/download/synaptik-mcp-linux-amd64)
 
 ```bash
 # Native binaries available in v0.0.5+ - or build from source:


### PR DESCRIPTION
- Remove Linux ARM64 from README.md native binaries section
- Remove Linux ARM64 from CD workflow release notes template
- Fix documentation to only show platforms we actually build:
  - macOS ARM64 (darwin-arm64) ✅
  - Linux x86_64 (linux-amd64) ✅
- Resolves duplication and incorrect platform advertising